### PR TITLE
Minor change to begin Python3 compatibility support.

### DIFF
--- a/gitdb/db/ref.py
+++ b/gitdb/db/ref.py
@@ -68,7 +68,7 @@ class ReferenceDB(CompoundDB):
                     db.databases()
                 # END verification
                 self._dbs.append(db)
-            except Exception, e:
+            except Exception as e:
                 # ignore invalid paths or issues
                 pass
         # END for each path to add


### PR DESCRIPTION
This is one small change to begin the process of providing Python3 support. 

This project, along with smmap, are the main reasons that GitPython does not have Python3 support
All three of these are in the top 360 packages downloaded on PyPy (see http://py3readiness.org/).
