### PR TITLE
Enable Appveyor CI for Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,49 @@
+# CI on Windows via appveyor
+environment:
+
+    matrix:
+        ## MINGW
+        #
+      - PYTHON: "C:\\Python27"
+        PYTHON_VERSION: "2.7"
+      - PYTHON: "C:\\Python34-x64"
+        PYTHON_VERSION: "3.4"
+      - PYTHON: "C:\\Python35-x64"
+        PYTHON_VERSION: "3.5"
+      - PYTHON: "C:\\Miniconda35-x64"
+        PYTHON_VERSION: "3.5"
+        IS_CONDA: "yes"
+
+install:
+    - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
+
+    ## Print configuration for debugging.
+    #
+    - |
+        echo %PATH%
+        uname -a
+        where python pip pip2 pip3 pip34
+        python --version
+        python -c "import struct; print(struct.calcsize('P') * 8)"
+
+    - IF "%IS_CONDA%"=="yes" (
+        conda info -a &
+        conda install --yes --quiet  pip
+      )
+    - pip install  nose wheel coveralls
+
+    ## For commits performed with the default user.
+    - |
+        git config --global user.email "travis@ci.com"
+        git config --global user.name "Travis Runner"
+
+    - pip install -e .
+
+build: false
+
+test_script:
+    -   IF "%PYTHON_VERSION%"=="3.5" (
+            nosetests -v --with-coverage
+        ) ELSE (
+            nosetests -v
+        )

--- a/README.rst
+++ b/README.rst
@@ -43,8 +43,8 @@ Once the clone is complete, please be sure to initialize the submodules using
  cd gitdb
  git submodule update --init
 
-Run the tests with 
- 
+Run the tests with
+
  nosetests
 
 DEVELOPMENT
@@ -52,13 +52,12 @@ DEVELOPMENT
 
 .. image:: https://travis-ci.org/gitpython-developers/gitdb.svg?branch=master
     :target: https://travis-ci.org/gitpython-developers/gitdb
-
+.. image:: https://ci.appveyor.com/api/projects/status/2qa4km4ln7bfv76r/branch/master?svg=true&passingText=windows%20OK&failingText=windows%20failed
+    :target: https://ci.appveyor.com/project/ankostis/gitpython/branch/master)
 .. image:: https://coveralls.io/repos/gitpython-developers/gitdb/badge.png
     :target: https://coveralls.io/r/gitpython-developers/gitdb
-
 .. image:: http://www.issuestats.com/github/gitpython-developers/gitdb/badge/pr
     :target: http://www.issuestats.com/github/gitpython-developers/gitdb
-
 .. image:: http://www.issuestats.com/github/gitpython-developers/gitdb/badge/issue
     :target: http://www.issuestats.com/github/gitpython-developers/gitdb
 

--- a/gitdb/test/performance/test_pack.py
+++ b/gitdb/test/performance/test_pack.py
@@ -36,7 +36,7 @@ class TestPackedDBPerformance(TestBigRepoR):
         sha_list = list(pdb.sha_iter())
         elapsed = time() - st
         ns = len(sha_list)
-        print("PDB: looked up %i shas by index in %f s ( %f shas/s )" % (ns, elapsed, ns / elapsed), file=sys.stderr)
+        print("PDB: looked up %i shas by index in %f s ( %f shas/s )" % (ns, elapsed, ns / (elapsed or 1)), file=sys.stderr)
 
         # sha lookup: best-case and worst case access
         pdb_pack_info = pdb._pack_info
@@ -51,7 +51,7 @@ class TestPackedDBPerformance(TestBigRepoR):
         del(pdb._entities)
         pdb.entities()
         print("PDB: looked up %i sha in %i packs in %f s ( %f shas/s )" %
-              (ns, len(pdb.entities()), elapsed, ns / elapsed), file=sys.stderr)
+              (ns, len(pdb.entities()), elapsed, ns / (elapsed or 1)), file=sys.stderr)
         # END for each random mode
 
         # query info and streams only
@@ -62,7 +62,7 @@ class TestPackedDBPerformance(TestBigRepoR):
                 pdb_fun(sha)
             elapsed = time() - st
             print("PDB: Obtained %i object %s by sha in %f s ( %f items/s )" %
-                  (max_items, pdb_fun.__name__.upper(), elapsed, max_items / elapsed), file=sys.stderr)
+                  (max_items, pdb_fun.__name__.upper(), elapsed, max_items / (elapsed or 1)), file=sys.stderr)
         # END for each function
 
         # retrieve stream and read all
@@ -78,7 +78,7 @@ class TestPackedDBPerformance(TestBigRepoR):
         elapsed = time() - st
         total_kib = total_size / 1000
         print("PDB: Obtained %i streams by sha and read all bytes totallying %i KiB ( %f KiB / s ) in %f s ( %f streams/s )" %
-              (max_items, total_kib, total_kib / elapsed, elapsed, max_items / elapsed), file=sys.stderr)
+              (max_items, total_kib, total_kib / (elapsed or 1), elapsed, max_items / (elapsed or 1)), file=sys.stderr)
 
     @skip_on_travis_ci
     def test_loose_correctness(self):
@@ -129,5 +129,5 @@ class TestPackedDBPerformance(TestBigRepoR):
             # END for each entity
             elapsed = time() - st
             print("PDB: verified %i objects (crc=%i) in %f s ( %f objects/s )" %
-                  (count, crc, elapsed, count / elapsed), file=sys.stderr)
+                  (count, crc, elapsed, count / (elapsed or 1)), file=sys.stderr)
         # END for each verify mode

--- a/gitdb/test/performance/test_pack_streaming.py
+++ b/gitdb/test/performance/test_pack_streaming.py
@@ -52,14 +52,14 @@ class TestPackStreamingPerformance(TestBigRepoR):
         # END gather objects for pack-writing
         elapsed = time() - st
         print("PDB Streaming: Got %i streams by sha in in %f s ( %f streams/s )" %
-              (ni, elapsed, ni / elapsed), file=sys.stderr)
+              (ni, elapsed, ni / (elapsed or 1)), file=sys.stderr)
 
         st = time()
         PackEntity.write_pack((pdb.stream(sha) for sha in pdb.sha_iter()), ostream.write, object_count=ni)
         elapsed = time() - st
         total_kb = ostream.bytes_written() / 1000
         print(sys.stderr, "PDB Streaming: Wrote pack of size %i kb in %f s (%f kb/s)" %
-              (total_kb, elapsed, total_kb / elapsed), sys.stderr)
+              (total_kb, elapsed, total_kb / (elapsed or 1)), sys.stderr)
 
     @skip_on_travis_ci
     def test_stream_reading(self):
@@ -82,4 +82,4 @@ class TestPackStreamingPerformance(TestBigRepoR):
         elapsed = time() - st
         total_kib = total_size / 1000
         print(sys.stderr, "PDB Streaming: Got %i streams by sha and read all bytes totallying %i KiB ( %f KiB / s ) in %f s ( %f streams/s )" %
-              (ni, total_kib, total_kib / elapsed, elapsed, ni / elapsed), sys.stderr)
+              (ni, total_kib, total_kib / (elapsed or 1), elapsed, ni / (elapsed or 1)), sys.stderr)

--- a/gitdb/test/performance/test_stream.py
+++ b/gitdb/test/performance/test_stream.py
@@ -70,7 +70,7 @@ class TestObjDBPerformance(TestBigRepoR):
 
             size_kib = size / 1000
             print("Added %i KiB (filesize = %i KiB) of %s data to loose odb in %f s ( %f Write KiB / s)" %
-                  (size_kib, fsize_kib, desc, elapsed_add, size_kib / elapsed_add), file=sys.stderr)
+                  (size_kib, fsize_kib, desc, elapsed_add, size_kib / (elapsed_add or 1)), file=sys.stderr)
 
             # reading all at once
             st = time()
@@ -81,7 +81,7 @@ class TestObjDBPerformance(TestBigRepoR):
             stream.seek(0)
             assert shadata == stream.getvalue()
             print("Read %i KiB of %s data at once from loose odb in %f s ( %f Read KiB / s)" %
-                  (size_kib, desc, elapsed_readall, size_kib / elapsed_readall), file=sys.stderr)
+                  (size_kib, desc, elapsed_readall, size_kib / (elapsed_readall or 1)), file=sys.stderr)
 
             # reading in chunks of 1 MiB
             cs = 512 * 1000
@@ -101,7 +101,7 @@ class TestObjDBPerformance(TestBigRepoR):
 
             cs_kib = cs / 1000
             print("Read %i KiB of %s data in %i KiB chunks from loose odb in %f s ( %f Read KiB / s)" %
-                  (size_kib, desc, cs_kib, elapsed_readchunks, size_kib / elapsed_readchunks), file=sys.stderr)
+                  (size_kib, desc, cs_kib, elapsed_readchunks, size_kib / (elapsed_readchunks or 1)), file=sys.stderr)
 
             # del db file so we keep something to do
             os.remove(db_file)

--- a/gitdb/test/test_pack.py
+++ b/gitdb/test/test_pack.py
@@ -188,7 +188,8 @@ class TestPack(TestBase):
 
         # pack writing - write all packs into one
         # index path can be None
-        pack_path = tempfile.mktemp('', "pack", rw_dir)
+        pack_path1 = tempfile.mktemp('', "pack1", rw_dir)
+        pack_path2 = tempfile.mktemp('', "pack2", rw_dir)
         index_path = tempfile.mktemp('', 'index', rw_dir)
         iteration = 0
 
@@ -196,7 +197,9 @@ class TestPack(TestBase):
             for obj in pack_objs:
                 obj.stream.seek(0)
         # END utility
-        for ppath, ipath, num_obj in zip((pack_path, ) * 2, (index_path, None), (len(pack_objs), None)):
+        for ppath, ipath, num_obj in zip((pack_path1, pack_path2),
+                                         (index_path, None),
+                                         (len(pack_objs), None)):
             iwrite = None
             if ipath:
                 ifile = open(ipath, 'wb')
@@ -214,7 +217,7 @@ class TestPack(TestBase):
             assert os.path.getsize(ppath) > 100
 
             # verify pack
-            pf = PackFile(ppath)
+            pf = PackFile(ppath)  # FIXME: Leaks file-pointer(s)!
             assert pf.size() == len(pack_objs)
             assert pf.version() == PackFile.pack_version_default
             assert pf.checksum() == pack_sha


### PR DESCRIPTION
- 3 errors remain in all python versions (py27, py34, py35, conda35).
- One set of errors fixed: div-by-zero on elapsed times - Appveyor must be quick.
