### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,10 +6,10 @@ GitDB allows you to access bare git repositories for reading and writing. It aim
 Installation
 ============
 
-.. image:: https://pypip.in/version/gitdb/badge.svg
+.. image:: https://img.shields.io/pypi/v/gitdb.svg
     :target: https://pypi.python.org/pypi/gitdb/
     :alt: Latest Version
-.. image:: https://pypip.in/py_versions/gitdb/badge.svg
+.. image:: https://img.shields.io/pypi/pyversions/gitdb.svg
     :target: https://pypi.python.org/pypi/gitdb/
     :alt: Supported Python versions
 .. image:: https://readthedocs.org/projects/gitdb/badge/?version=latest


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20gitdb))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `gitdb`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.