### PR TITLE
loose: rename only if needed

### DIFF
--- a/gitdb/db/loose.py
+++ b/gitdb/db/loose.py
@@ -225,16 +225,12 @@ class LooseObjectDB(FileDBBase, ObjectDBR, ObjectDBW):
             if not isdir(obj_dir):
                 mkdir(obj_dir)
             # END handle destination directory
-            # rename onto existing doesn't work on windows
-            if os.name == 'nt':
-                if isfile(obj_path):
-                    remove(tmp_path)
-                else:
-                    rename(tmp_path, obj_path)
-                # end rename only if needed
+            # rename onto existing doesn't work on NTFS
+            if isfile(obj_path):
+                remove(tmp_path)
             else:
                 rename(tmp_path, obj_path)
-            # END handle win32
+            # end rename only if needed
 
             # make sure its readable for all ! It started out as rw-- tmp file
             # but needs to be rwrr


### PR DESCRIPTION
Our user was experiencing issue [1] when using a git repository on NTFS mount
running on Linux. The current check checks if we are running on Windows, but
it should really check if we are on NTFS. And since checking fs type is not
that trivial and not efficient, it is simpler and better to just always apply
NTFS-specific logic, since it works on other filesystems as well.

[1] https://github.com/iterative/dvc/issues/1880#issuecomment-483253764