### PR TITLE
Fix deprecated calls for Python 3.9

### DIFF
--- a/gitdb/pack.py
+++ b/gitdb/pack.py
@@ -410,7 +410,7 @@ class PackIndexFile(LazyMixin):
         if self._version == 2:
             # read stream to array, convert to tuple
             a = array.array('I')    # 4 byte unsigned int, long are 8 byte on 64 bit it appears
-            a.fromstring(buffer(self._cursor.map(), self._pack_offset, self._pack_64_offset - self._pack_offset))
+            a.frombytes(buffer(self._cursor.map(), self._pack_offset, self._pack_64_offset - self._pack_offset))
 
             # networkbyteorder to something array likes more
             if sys.byteorder == 'little':

--- a/gitdb/test/lib.py
+++ b/gitdb/test/lib.py
@@ -157,7 +157,7 @@ def make_bytes(size_in_bytes, randomize=False):
         random.shuffle(producer)
     # END randomize
     a = array('i', producer)
-    return a.tostring()
+    return a.tobytes()
 
 
 def make_object(type, data):


### PR DESCRIPTION
The array methods fromstring/tostring have been deprecated since Python 3.2. Python 3.9 removes them completely.

This was discovered when trying to build gitdb package for Fedora 33.
https://bugzilla.redhat.com/show_bug.cgi?id=1788660