### PR TITLE
Remove Python 2 compatibility shims

### DIFF
--- a/gitdb/db/loose.py
+++ b/gitdb/db/loose.py
@@ -50,11 +50,11 @@ from gitdb.fun import (
     stream_copy
 )
 
-from gitdb.utils.compat import MAXSIZE
 from gitdb.utils.encoding import force_bytes
 
 import tempfile
 import os
+import sys
 
 
 __all__ = ('LooseObjectDB', )
@@ -196,7 +196,7 @@ class LooseObjectDB(FileDBBase, ObjectDBR, ObjectDBW):
                 if istream.binsha is not None:
                     # copy as much as possible, the actual uncompressed item size might
                     # be smaller than the compressed version
-                    stream_copy(istream.read, writer.write, MAXSIZE, self.stream_chunk_size)
+                    stream_copy(istream.read, writer.write, sys.maxsize, self.stream_chunk_size)
                 else:
                     # write object with header, we have to make a new one
                     write_object(istream.type, istream.size, istream.read, writer.write,

--- a/gitdb/db/pack.py
+++ b/gitdb/db/pack.py
@@ -18,7 +18,6 @@ from gitdb.exc import (
 )
 
 from gitdb.pack import PackEntity
-from gitdb.utils.compat import xrange
 
 from functools import reduce
 
@@ -107,7 +106,7 @@ class PackedDB(FileDBBase, ObjectDBR, CachingDB, LazyMixin):
         for entity in self.entities():
             index = entity.index()
             sha_by_index = index.sha
-            for index in xrange(index.size()):
+            for index in range(index.size()):
                 yield sha_by_index(index)
             # END for each index
         # END for each entity

--- a/gitdb/fun.py
+++ b/gitdb/fun.py
@@ -16,7 +16,7 @@ from functools import reduce
 
 from gitdb.const import NULL_BYTE, BYTE_SPACE
 from gitdb.utils.encoding import force_text
-from gitdb.utils.compat import buffer, PY3
+from gitdb.utils.compat import PY3
 from gitdb.typ import (
     str_blob_type,
     str_commit_type,
@@ -101,7 +101,7 @@ def delta_chunk_apply(dc, bbuf, write):
     :param write: write method to call with data to write"""
     if dc.data is None:
         # COPY DATA FROM SOURCE
-        write(buffer(bbuf, dc.so, dc.ts))
+        write(bbuf[dc.so:dc.so + dc.ts])
     else:
         # APPEND DATA
         # whats faster: if + 4 function calls or just a write with a slice ?
@@ -698,7 +698,7 @@ def apply_delta_data(src_buf, src_buf_size, delta_buf, delta_buf_size, write):
                 if (rbound < cp_size or
                         rbound > src_buf_size):
                     break
-                write(buffer(src_buf, cp_off, cp_size))
+                write(src_buf[cp_off:cp_off + cp_size])
             elif c:
                 write(db[i:i + c])
                 i += c
@@ -741,7 +741,7 @@ def apply_delta_data(src_buf, src_buf_size, delta_buf, delta_buf_size, write):
                 if (rbound < cp_size or
                         rbound > src_buf_size):
                     break
-                write(buffer(src_buf, cp_off, cp_size))
+                write(src_buf[cp_off:cp_off + cp_size])
             elif c:
                 write(db[i:i + c])
                 i += c

--- a/gitdb/fun.py
+++ b/gitdb/fun.py
@@ -16,7 +16,6 @@ from functools import reduce
 
 from gitdb.const import NULL_BYTE, BYTE_SPACE
 from gitdb.utils.encoding import force_text
-from gitdb.utils.compat import PY3
 from gitdb.typ import (
     str_blob_type,
     str_commit_type,
@@ -424,20 +423,12 @@ def pack_object_header_info(data):
     type_id = (c >> 4) & 7          # numeric type
     size = c & 15                   # starting size
     s = 4                           # starting bit-shift size
-    if PY3:
-        while c & 0x80:
-            c = byte_ord(data[i])
-            i += 1
-            size += (c & 0x7f) << s
-            s += 7
-        # END character loop
-    else:
-        while c & 0x80:
-            c = ord(data[i])
-            i += 1
-            size += (c & 0x7f) << s
-            s += 7
-        # END character loop
+    while c & 0x80:
+        c = byte_ord(data[i])
+        i += 1
+        size += (c & 0x7f) << s
+        s += 7
+    # END character loop
     # end performance at expense of maintenance ...
     return (type_id, size, i)
 
@@ -450,28 +441,16 @@ def create_pack_object_header(obj_type, obj_size):
     :param obj_type: pack type_id of the object
     :param obj_size: uncompressed size in bytes of the following object stream"""
     c = 0       # 1 byte
-    if PY3:
-        hdr = bytearray()  # output string
+    hdr = bytearray()  # output string
 
-        c = (obj_type << 4) | (obj_size & 0xf)
-        obj_size >>= 4
-        while obj_size:
-            hdr.append(c | 0x80)
-            c = obj_size & 0x7f
-            obj_size >>= 7
-        # END until size is consumed
-        hdr.append(c)
-    else:
-        hdr = bytes()  # output string
-
-        c = (obj_type << 4) | (obj_size & 0xf)
-        obj_size >>= 4
-        while obj_size:
-            hdr += chr(c | 0x80)
-            c = obj_size & 0x7f
-            obj_size >>= 7
-        # END until size is consumed
-        hdr += chr(c)
+    c = (obj_type << 4) | (obj_size & 0xf)
+    obj_size >>= 4
+    while obj_size:
+        hdr.append(c | 0x80)
+        c = obj_size & 0x7f
+        obj_size >>= 7
+    # END until size is consumed
+    hdr.append(c)
     # end handle interpreter
     return hdr
 
@@ -484,26 +463,15 @@ def msb_size(data, offset=0):
     i = 0
     l = len(data)
     hit_msb = False
-    if PY3:
-        while i < l:
-            c = data[i + offset]
-            size |= (c & 0x7f) << i * 7
-            i += 1
-            if not c & 0x80:
-                hit_msb = True
-                break
-            # END check msb bit
-        # END while in range
-    else:
-        while i < l:
-            c = ord(data[i + offset])
-            size |= (c & 0x7f) << i * 7
-            i += 1
-            if not c & 0x80:
-                hit_msb = True
-                break
-            # END check msb bit
-        # END while in range
+    while i < l:
+        c = data[i + offset]
+        size |= (c & 0x7f) << i * 7
+        i += 1
+        if not c & 0x80:
+            hit_msb = True
+            break
+        # END check msb bit
+    # END while in range
     # end performance ...
     if not hit_msb:
         raise AssertionError("Could not find terminating MSB byte in data stream")
@@ -663,93 +631,48 @@ def apply_delta_data(src_buf, src_buf_size, delta_buf, delta_buf_size, write):
     **Note:** transcribed to python from the similar routine in patch-delta.c"""
     i = 0
     db = delta_buf
-    if PY3:
-        while i < delta_buf_size:
-            c = db[i]
-            i += 1
-            if c & 0x80:
-                cp_off, cp_size = 0, 0
-                if (c & 0x01):
-                    cp_off = db[i]
-                    i += 1
-                if (c & 0x02):
-                    cp_off |= (db[i] << 8)
-                    i += 1
-                if (c & 0x04):
-                    cp_off |= (db[i] << 16)
-                    i += 1
-                if (c & 0x08):
-                    cp_off |= (db[i] << 24)
-                    i += 1
-                if (c & 0x10):
-                    cp_size = db[i]
-                    i += 1
-                if (c & 0x20):
-                    cp_size |= (db[i] << 8)
-                    i += 1
-                if (c & 0x40):
-                    cp_size |= (db[i] << 16)
-                    i += 1
+    while i < delta_buf_size:
+        c = db[i]
+        i += 1
+        if c & 0x80:
+            cp_off, cp_size = 0, 0
+            if (c & 0x01):
+                cp_off = db[i]
+                i += 1
+            if (c & 0x02):
+                cp_off |= (db[i] << 8)
+                i += 1
+            if (c & 0x04):
+                cp_off |= (db[i] << 16)
+                i += 1
+            if (c & 0x08):
+                cp_off |= (db[i] << 24)
+                i += 1
+            if (c & 0x10):
+                cp_size = db[i]
+                i += 1
+            if (c & 0x20):
+                cp_size |= (db[i] << 8)
+                i += 1
+            if (c & 0x40):
+                cp_size |= (db[i] << 16)
+                i += 1
 
-                if not cp_size:
-                    cp_size = 0x10000
+            if not cp_size:
+                cp_size = 0x10000
 
-                rbound = cp_off + cp_size
-                if (rbound < cp_size or
-                        rbound > src_buf_size):
-                    break
-                write(src_buf[cp_off:cp_off + cp_size])
-            elif c:
-                write(db[i:i + c])
-                i += c
-            else:
-                raise ValueError("unexpected delta opcode 0")
-            # END handle command byte
-        # END while processing delta data
-    else:
-        while i < delta_buf_size:
-            c = ord(db[i])
-            i += 1
-            if c & 0x80:
-                cp_off, cp_size = 0, 0
-                if (c & 0x01):
-                    cp_off = ord(db[i])
-                    i += 1
-                if (c & 0x02):
-                    cp_off |= (ord(db[i]) << 8)
-                    i += 1
-                if (c & 0x04):
-                    cp_off |= (ord(db[i]) << 16)
-                    i += 1
-                if (c & 0x08):
-                    cp_off |= (ord(db[i]) << 24)
-                    i += 1
-                if (c & 0x10):
-                    cp_size = ord(db[i])
-                    i += 1
-                if (c & 0x20):
-                    cp_size |= (ord(db[i]) << 8)
-                    i += 1
-                if (c & 0x40):
-                    cp_size |= (ord(db[i]) << 16)
-                    i += 1
-
-                if not cp_size:
-                    cp_size = 0x10000
-
-                rbound = cp_off + cp_size
-                if (rbound < cp_size or
-                        rbound > src_buf_size):
-                    break
-                write(src_buf[cp_off:cp_off + cp_size])
-            elif c:
-                write(db[i:i + c])
-                i += c
-            else:
-                raise ValueError("unexpected delta opcode 0")
-            # END handle command byte
-        # END while processing delta data
-    # end save byte_ord call and prevent performance regression in py2
+            rbound = cp_off + cp_size
+            if (rbound < cp_size or
+                    rbound > src_buf_size):
+                break
+            write(src_buf[cp_off:cp_off + cp_size])
+        elif c:
+            write(db[i:i + c])
+            i += c
+        else:
+            raise ValueError("unexpected delta opcode 0")
+        # END handle command byte
+    # END while processing delta data
 
     # yes, lets use the exact same error message that git uses :)
     assert i == delta_buf_size, "delta replay has gone wild"

--- a/gitdb/fun.py
+++ b/gitdb/fun.py
@@ -16,7 +16,7 @@ from functools import reduce
 
 from gitdb.const import NULL_BYTE, BYTE_SPACE
 from gitdb.utils.encoding import force_text
-from gitdb.utils.compat import buffer, xrange, PY3
+from gitdb.utils.compat import buffer, PY3
 from gitdb.typ import (
     str_blob_type,
     str_commit_type,
@@ -264,7 +264,7 @@ class DeltaChunkList(list):
                     # if first_data_index is not None:
                     nd = StringIO()                     # new data
                     so = self[first_data_index].to      # start offset in target buffer
-                    for x in xrange(first_data_index, i - 1):
+                    for x in range(first_data_index, i - 1):
                         xdc = self[x]
                         nd.write(xdc.data[:xdc.ts])
                     # END collect data

--- a/gitdb/fun.py
+++ b/gitdb/fun.py
@@ -16,7 +16,7 @@ from functools import reduce
 
 from gitdb.const import NULL_BYTE, BYTE_SPACE
 from gitdb.utils.encoding import force_text
-from gitdb.utils.compat import izip, buffer, xrange, PY3
+from gitdb.utils.compat import buffer, xrange, PY3
 from gitdb.typ import (
     str_blob_type,
     str_commit_type,
@@ -314,7 +314,7 @@ class DeltaChunkList(list):
         right.next()
         # this is very pythonic - we might have just use index based access here,
         # but this could actually be faster
-        for lft, rgt in izip(left, right):
+        for lft, rgt in zip(left, right):
             assert lft.rbound() == rgt.to
             assert lft.to + lft.ts == rgt.to
         # END for each pair

--- a/gitdb/pack.py
+++ b/gitdb/pack.py
@@ -64,7 +64,6 @@ from binascii import crc32
 from gitdb.const import NULL_BYTE
 from gitdb.utils.compat import (
     buffer, 
-    xrange,
     to_bytes
 )
 
@@ -206,7 +205,7 @@ class IndexWriter(object):
         for t in self._objs:
             tmplist[byte_ord(t[0][0])] += 1
         # END prepare fanout
-        for i in xrange(255):
+        for i in range(255):
             v = tmplist[i]
             sha_write(pack('>L', v))
             tmplist[i + 1] += v
@@ -375,7 +374,7 @@ class PackIndexFile(LazyMixin):
         d = self._cursor.map()
         out = list()
         append = out.append
-        for i in xrange(256):
+        for i in range(256):
             append(unpack_from('>L', d, byte_offset + i * 4)[0])
         # END for each entry
         return out
@@ -416,7 +415,7 @@ class PackIndexFile(LazyMixin):
                 a.byteswap()
             return a
         else:
-            return tuple(self.offset(index) for index in xrange(self.size()))
+            return tuple(self.offset(index) for index in range(self.size()))
         # END handle version
 
     def sha_to_index(self, sha):
@@ -715,7 +714,7 @@ class PackEntity(LazyMixin):
         """Iterate over all objects in our index and yield their OInfo or OStream instences"""
         _sha = self._index.sha
         _object = self._object
-        for index in xrange(self._index.size()):
+        for index in range(self._index.size()):
             yield _object(_sha(index), as_stream, index)
         # END for each index
 

--- a/gitdb/pack.py
+++ b/gitdb/pack.py
@@ -62,10 +62,7 @@ from struct import pack
 from binascii import crc32
 
 from gitdb.const import NULL_BYTE
-from gitdb.utils.compat import (
-    buffer, 
-    to_bytes
-)
+from gitdb.utils.compat import to_bytes
 
 import tempfile
 import array
@@ -117,7 +114,7 @@ def pack_object_at(cursor, offset, as_stream):
     # END handle type id
     abs_data_offset = offset + total_rela_offset
     if as_stream:
-        stream = DecompressMemMapReader(buffer(data, total_rela_offset), False, uncomp_size)
+        stream = DecompressMemMapReader(data[total_rela_offset:], False, uncomp_size)
         if delta_info is None:
             return abs_data_offset, OPackStream(offset, type_id, uncomp_size, stream)
         else:
@@ -408,7 +405,7 @@ class PackIndexFile(LazyMixin):
         if self._version == 2:
             # read stream to array, convert to tuple
             a = array.array('I')    # 4 byte unsigned int, long are 8 byte on 64 bit it appears
-            a.frombytes(buffer(self._cursor.map(), self._pack_offset, self._pack_64_offset - self._pack_offset))
+            a.frombytes(self._cursor.map()[self._pack_offset:self._pack_64_offset])
 
             # networkbyteorder to something array likes more
             if sys.byteorder == 'little':
@@ -836,7 +833,7 @@ class PackEntity(LazyMixin):
             while cur_pos < next_offset:
                 rbound = min(cur_pos + chunk_size, next_offset)
                 size = rbound - cur_pos
-                this_crc_value = crc_update(buffer(pack_data, cur_pos, size), this_crc_value)
+                this_crc_value = crc_update(pack_data[cur_pos:cur_pos + size], this_crc_value)
                 cur_pos += size
             # END window size loop
 

--- a/gitdb/pack.py
+++ b/gitdb/pack.py
@@ -63,7 +63,6 @@ from binascii import crc32
 
 from gitdb.const import NULL_BYTE
 from gitdb.utils.compat import (
-    izip, 
     buffer, 
     xrange,
     to_bytes
@@ -696,7 +695,7 @@ class PackEntity(LazyMixin):
             iter_offsets = iter(offsets_sorted)
             iter_offsets_plus_one = iter(offsets_sorted)
             next(iter_offsets_plus_one)
-            consecutive = izip(iter_offsets, iter_offsets_plus_one)
+            consecutive = zip(iter_offsets, iter_offsets_plus_one)
 
             offset_map = dict(consecutive)
 

--- a/gitdb/stream.py
+++ b/gitdb/stream.py
@@ -27,7 +27,6 @@ from gitdb.util import (
 )
 
 from gitdb.const import NULL_BYTE, BYTE_SPACE
-from gitdb.utils.compat import buffer
 from gitdb.utils.encoding import force_bytes
 
 has_perf_mod = False
@@ -278,7 +277,7 @@ class DecompressMemMapReader(LazyMixin):
         # END adjust winsize
 
         # takes a slice, but doesn't copy the data, it says ...
-        indata = buffer(self._m, self._cws, self._cwe - self._cws)
+        indata = self._m[self._cws:self._cwe]
 
         # get the actual window end to be sure we don't use it for computations
         self._cwe = self._cws + len(indata)
@@ -414,7 +413,7 @@ class DeltaApplyReader(LazyMixin):
             buf = dstream.read(512)         # read the header information + X
             offset, src_size = msb_size(buf)
             offset, target_size = msb_size(buf, offset)
-            buffer_info_list.append((buffer(buf, offset), offset, src_size, target_size))
+            buffer_info_list.append((buf[offset:], offset, src_size, target_size))
             max_target_size = max(max_target_size, target_size)
         # END for each delta stream
 

--- a/gitdb/test/db/lib.py
+++ b/gitdb/test/db/lib.py
@@ -23,7 +23,6 @@ from gitdb.base import (
 
 from gitdb.exc import BadObject
 from gitdb.typ import str_blob_type
-from gitdb.utils.compat import xrange
 
 from io import BytesIO
 
@@ -45,7 +44,7 @@ class TestDBBase(TestBase):
         # write a bunch of objects and query their streams and info
         null_objs = db.size()
         ni = 250
-        for i in xrange(ni):
+        for i in range(ni):
             data = pack(">L", i)
             istream = IStream(str_blob_type, len(data), BytesIO(data))
             new_istream = db.store(istream)

--- a/gitdb/test/lib.py
+++ b/gitdb/test/lib.py
@@ -4,7 +4,6 @@
 # the New BSD License: http://www.opensource.org/licenses/bsd-license.php
 """Utilities used in ODB testing"""
 from gitdb import OStream
-from gitdb.utils.compat import xrange
 
 import sys
 import random
@@ -151,7 +150,7 @@ def make_bytes(size_in_bytes, randomize=False):
     """:return: string with given size in bytes
     :param randomize: try to produce a very random stream"""
     actual_size = size_in_bytes // 4
-    producer = xrange(actual_size)
+    producer = range(actual_size)
     if randomize:
         producer = list(producer)
         random.shuffle(producer)

--- a/gitdb/test/performance/test_pack.py
+++ b/gitdb/test/performance/test_pack.py
@@ -17,7 +17,6 @@ from gitdb import (
 from gitdb.typ import str_blob_type
 from gitdb.exc import UnsupportedOperation
 from gitdb.db.pack import PackedDB
-from gitdb.utils.compat import xrange
 from gitdb.test.lib import skip_on_travis_ci
 
 import sys
@@ -118,7 +117,7 @@ class TestPackedDBPerformance(TestBigRepoR):
             for entity in pdb.entities():
                 pack_verify = entity.is_valid_stream
                 sha_by_index = entity.index().sha
-                for index in xrange(entity.index().size()):
+                for index in range(entity.index().size()):
                     try:
                         assert pack_verify(sha_by_index(index), use_crc=crc)
                         count += 1

--- a/gitdb/test/test_pack.py
+++ b/gitdb/test/test_pack.py
@@ -25,7 +25,6 @@ from gitdb.base import (
 from gitdb.fun import delta_types
 from gitdb.exc import UnsupportedOperation
 from gitdb.util import to_bin_sha
-from gitdb.utils.compat import xrange
 
 from nose import SkipTest
 
@@ -58,7 +57,7 @@ class TestPack(TestBase):
         assert len(index.offsets()) == size
 
         # get all data of all objects
-        for oidx in xrange(index.size()):
+        for oidx in range(index.size()):
             sha = index.sha(oidx)
             assert oidx == index.sha_to_index(sha)
 

--- a/gitdb/test/test_pack.py
+++ b/gitdb/test/test_pack.py
@@ -27,11 +27,6 @@ from gitdb.exc import UnsupportedOperation
 from gitdb.util import to_bin_sha
 from gitdb.utils.compat import xrange
 
-try:
-    from itertools import izip
-except ImportError:
-    izip = zip
-
 from nose import SkipTest
 
 import os
@@ -155,7 +150,7 @@ class TestPack(TestBase):
             pack_objs.extend(entity.stream_iter())
 
             count = 0
-            for info, stream in izip(entity.info_iter(), entity.stream_iter()):
+            for info, stream in zip(entity.info_iter(), entity.stream_iter()):
                 count += 1
                 assert info.binsha == stream.binsha
                 assert len(info.binsha) == 20

--- a/gitdb/utils/compat.py
+++ b/gitdb/utils/compat.py
@@ -1,3 +1,0 @@
-import sys
-
-PY3 = sys.version_info[0] == 3

--- a/gitdb/utils/compat.py
+++ b/gitdb/utils/compat.py
@@ -1,8 +1,3 @@
 import sys
 
 PY3 = sys.version_info[0] == 3
-
-try:
-    MAXSIZE = sys.maxint
-except AttributeError:
-    MAXSIZE = sys.maxsize

--- a/gitdb/utils/compat.py
+++ b/gitdb/utils/compat.py
@@ -3,11 +3,9 @@ import sys
 PY3 = sys.version_info[0] == 3
 
 try:
-    from itertools import izip
     xrange = xrange
 except ImportError:
     # py3
-    izip = zip
     xrange = range
 # end handle python version
 

--- a/gitdb/utils/compat.py
+++ b/gitdb/utils/compat.py
@@ -4,22 +4,12 @@ PY3 = sys.version_info[0] == 3
 
 try:
     # Python 2
-    buffer = buffer
     memoryview = buffer
     # Assume no memory view ...
     def to_bytes(i):
         return i
 except NameError:
     # Python 3 has no `buffer`; only `memoryview`
-    # However, it's faster to just slice the object directly, maybe it keeps a view internally
-    def buffer(obj, offset, size=None):
-        if size is None:
-            # return memoryview(obj)[offset:]
-            return obj[offset:]
-        else:
-            # return memoryview(obj)[offset:offset+size]
-            return obj[offset:offset + size]
-    # end buffer reimplementation
     # smmap can return memory view objects, which can't be compared as buffers/bytes can ... 
     def to_bytes(i):
         if isinstance(i, memoryview):

--- a/gitdb/utils/compat.py
+++ b/gitdb/utils/compat.py
@@ -3,13 +3,6 @@ import sys
 PY3 = sys.version_info[0] == 3
 
 try:
-    xrange = xrange
-except ImportError:
-    # py3
-    xrange = range
-# end handle python version
-
-try:
     # Python 2
     buffer = buffer
     memoryview = buffer

--- a/gitdb/utils/compat.py
+++ b/gitdb/utils/compat.py
@@ -3,17 +3,6 @@ import sys
 PY3 = sys.version_info[0] == 3
 
 try:
-    # Python 2
-    def to_bytes(i):
-        return i
-except NameError:
-    # smmap can return memory view objects, which can't be compared as buffers/bytes can ... 
-    def to_bytes(i):
-        if isinstance(i, memoryview):
-            return i.tobytes()
-        return i
-
-try:
     MAXSIZE = sys.maxint
 except AttributeError:
     MAXSIZE = sys.maxsize

--- a/gitdb/utils/compat.py
+++ b/gitdb/utils/compat.py
@@ -4,19 +4,14 @@ PY3 = sys.version_info[0] == 3
 
 try:
     # Python 2
-    memoryview = buffer
-    # Assume no memory view ...
     def to_bytes(i):
         return i
 except NameError:
-    # Python 3 has no `buffer`; only `memoryview`
     # smmap can return memory view objects, which can't be compared as buffers/bytes can ... 
     def to_bytes(i):
         if isinstance(i, memoryview):
             return i.tobytes()
         return i
-
-    memoryview = memoryview
 
 try:
     MAXSIZE = sys.maxint

--- a/gitdb/utils/encoding.py
+++ b/gitdb/utils/encoding.py
@@ -1,11 +1,3 @@
-from gitdb.utils import compat
-
-if compat.PY3:
-    text_type = str
-else:
-    text_type = unicode
-
-
 def force_bytes(data, encoding="ascii"):
     if isinstance(data, bytes):
         return data
@@ -17,13 +9,10 @@ def force_bytes(data, encoding="ascii"):
 
 
 def force_text(data, encoding="utf-8"):
-    if isinstance(data, text_type):
+    if isinstance(data, str):
         return data
 
     if isinstance(data, bytes):
         return data.decode(encoding)
 
-    if compat.PY3:
-        return text_type(data, encoding)
-    else:
-        return text_type(data)
+    return str(data, encoding)

--- a/gitdb/utils/encoding.py
+++ b/gitdb/utils/encoding.py
@@ -1,10 +1,8 @@
 from gitdb.utils import compat
 
 if compat.PY3:
-    string_types = (str, )
     text_type = str
 else:
-    string_types = (basestring, )
     text_type = unicode
 
 
@@ -12,7 +10,7 @@ def force_bytes(data, encoding="ascii"):
     if isinstance(data, bytes):
         return data
 
-    if isinstance(data, string_types):
+    if isinstance(data, str):
         return data.encode(encoding)
 
     return data


### PR DESCRIPTION
This PR removes and replaces Python 2 compatibility shims, since Python 2 support was dropped with https://github.com/gitpython-developers/gitdb/commit/c880f6b0550770eee559091d6276a2e2b097a83a in 3.0.0:
 - Remove `compat.memoryview` and `compat.PY3`
 - Remove and replace `compat.buffer` and `compat.to_bytes`
 - Remove and replace `compat.izip` with `zip`, `compat.MAXSIZE` with `sys.maxsize`, `compat.xrange` with `range`
 - Remove and replace `encoding.string_types` and `encoding.text_type` with `str`
 - Remove and replace `izip` in `TestPack`