### PR TITLE
Set python_requires='>=3.4' (gitdb already has this requirement)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,5 @@ setup(
     long_description="This is a mirror package for `gitdb <https://pypi.org/project/gitdb/>`_. Consider installing it directly instead.",
     url="https://github.com/gitpython-developers/gitdb",
     install_requires=["gitdb>=4.0.1"],
+    python_requires='>=3.4',
 )


### PR DESCRIPTION
The python_requires='>=3.4'  is already set for gitdb and the gitdb2 python module has as a dependency gitdb>=4.0.1 that dropped Python 2 support after  python_requires='>=3.4'  was added in its `setup.py`. 

Will prevent users with Python 2.7 from downloading a sdist version they cannot build.

Note: supporting python_requires requires setuptools>=24.2.0 and pip>=9.0.0 to benefit from it.
Details here: https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires