### PR TITLE
Remove setup.cfg to have a pure python wheel 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1


### PR DESCRIPTION
As for the setup.cfg universal setting, this is actually an issue with the main gitdb package on the master branch rather than with the gitdb2 mirror package. The gitdb package has dropped support for Python 2, so it should be a Pure Python Wheel rather than a Universal Wheel