### PR TITLE
Fix exception causes in loose.py

### DIFF
--- a/gitdb/db/loose.py
+++ b/gitdb/db/loose.py
@@ -138,12 +138,12 @@ class LooseObjectDB(FileDBBase, ObjectDBR, ObjectDBW):
                 # try again without noatime
                 try:
                     return file_contents_ro_filepath(db_path)
-                except OSError:
-                    raise BadObject(sha)
+                except OSError as new_e:
+                    raise BadObject(sha) from new_e
                 # didn't work because of our flag, don't try it again
                 self._fd_open_flags = 0
             else:
-                raise BadObject(sha)
+                raise BadObject(sha) from e
             # END handle error
         # END exception handling
 


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. If you're interested, I can do it here too. I've done it on just one file right now. 

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 