### PR TITLE
Replace deprecated unittest aliases

### DIFF
--- a/gitdb/test/db/lib.py
+++ b/gitdb/test/db/lib.py
@@ -102,8 +102,8 @@ class TestDBBase(TestBase):
                     assert ostream.type == str_blob_type
                     assert ostream.size == len(data)
                 else:
-                    self.failUnlessRaises(BadObject, db.info, sha)
-                    self.failUnlessRaises(BadObject, db.stream, sha)
+                    self.assertRaises(BadObject, db.info, sha)
+                    self.assertRaises(BadObject, db.stream, sha)
 
                     # DIRECT STREAM COPY
                     # our data hase been written in object format to the StringIO

--- a/gitdb/test/db/test_git.py
+++ b/gitdb/test/db/test_git.py
@@ -43,7 +43,7 @@ class TestGitDB(TestDBBase):
             assert gdb.partial_to_complete_sha_hex(bin_to_hex(binsha)[:8 - (i % 2)]) == binsha
         # END for each sha
 
-        self.failUnlessRaises(BadObject, gdb.partial_to_complete_sha_hex, "0000")
+        self.assertRaises(BadObject, gdb.partial_to_complete_sha_hex, "0000")
 
     @with_rw_directory
     def test_writing(self, path):

--- a/gitdb/test/db/test_loose.py
+++ b/gitdb/test/db/test_loose.py
@@ -32,5 +32,5 @@ class TestLooseDB(TestDBBase):
             assert bin_to_hex(ldb.partial_to_complete_sha_hex(short_sha)) == long_sha
         # END for each sha
 
-        self.failUnlessRaises(BadObject, ldb.partial_to_complete_sha_hex, '0000')
+        self.assertRaises(BadObject, ldb.partial_to_complete_sha_hex, '0000')
         # raises if no object could be found

--- a/gitdb/test/db/test_pack.py
+++ b/gitdb/test/db/test_pack.py
@@ -84,4 +84,4 @@ class TestPackDB(TestDBBase):
         # assert num_ambiguous
 
         # non-existing
-        self.failUnlessRaises(BadObject, pdb.partial_to_complete_sha, b'\0\0', 4)
+        self.assertRaises(BadObject, pdb.partial_to_complete_sha, b'\0\0', 4)

--- a/gitdb/test/test_pack.py
+++ b/gitdb/test/test_pack.py
@@ -73,7 +73,7 @@ class TestPack(TestBase):
                 assert index.partial_sha_to_index(sha[:l], l * 2) == oidx
 
         # END for each object index in indexfile
-        self.failUnlessRaises(ValueError, index.partial_sha_to_index, "\0", 2)
+        self.assertRaises(ValueError, index.partial_sha_to_index, "\0", 2)
 
     def _assert_pack_file(self, pack, version, size):
         assert pack.version() == 2

--- a/gitdb/test/test_stream.py
+++ b/gitdb/test/test_stream.py
@@ -135,7 +135,7 @@ class TestStream(TestBase):
             ostream.close()
 
             # its closed already
-            self.failUnlessRaises(OSError, os.close, fd)
+            self.assertRaises(OSError, os.close, fd)
 
             # read everything back, compare to data we zip
             fd = os.open(path, os.O_RDONLY | getattr(os, 'O_BINARY', 0))

--- a/gitdb/test/test_util.py
+++ b/gitdb/test/test_util.py
@@ -40,8 +40,8 @@ class TestUtils(TestBase):
             lockfilepath = lfd._lockfilepath()
 
             # cannot end before it was started
-            self.failUnlessRaises(AssertionError, lfd.rollback)
-            self.failUnlessRaises(AssertionError, lfd.commit)
+            self.assertRaises(AssertionError, lfd.rollback)
+            self.assertRaises(AssertionError, lfd.commit)
 
             # open for writing
             assert not os.path.isfile(lockfilepath)
@@ -77,7 +77,7 @@ class TestUtils(TestBase):
             wfdstream = lfd.open(write=True, stream=True)       # this time as stream
             assert os.path.isfile(lockfilepath)
             # another one fails
-            self.failUnlessRaises(IOError, olfd.open)
+            self.assertRaises(IOError, olfd.open)
 
             wfdstream.write(new_data.encode("ascii"))
             lfd.commit()


### PR DESCRIPTION
`failUnlessRaises` is deprecated and should be replaced with `assertRaises`:

* https://docs.python.org/3/library/unittest.html#deprecated-aliases