### PR TITLE
Fix Sphinx warnings

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -120,7 +120,7 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['.static']
+#html_static_path = ['.static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/gitdb/db/base.py
+++ b/gitdb/db/base.py
@@ -33,6 +33,9 @@ class ObjectDBR(object):
     #{ Query Interface
     def has_object(self, sha):
         """
+        Whether the object identified by the given 20 bytes
+            binary sha is contained in the database
+
         :return: True if the object identified by the given 20 bytes
             binary sha is contained in the database"""
         raise NotImplementedError("To be implemented in subclass")
@@ -82,6 +85,8 @@ class ObjectDBW(object):
 
     def ostream(self):
         """
+        Return the output stream
+
         :return: overridden output stream this instance will write to, or None
             if it will write to the default stream"""
         return self._ostream

--- a/gitdb/db/mem.py
+++ b/gitdb/db/mem.py
@@ -92,6 +92,7 @@ class MemoryDB(ObjectDBR, ObjectDBW):
         """Copy the streams as identified by sha's yielded by sha_iter into the given odb
         The streams will be copied directly
         **Note:** the object will only be written if it did not exist in the target db
+
         :return: amount of streams actually copied into odb. If smaller than the amount
             of input shas, one or more objects did already exist in odb"""
         count = 0


### PR DESCRIPTION
Fixes https://github.com/gitpython-developers/gitdb/issues/71.

Two things:

* There is no `.static` dir in use, comment it out
* Docstrings usually need a new line between a summary and the params/return: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html

```console
$ python3 setup.py build_sphinx -b man
running build_sphinx
Running Sphinx v4.0.2
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [man]: all manpages
updating environment: 0 added, 0 changed, 0 removed
looking for now-outdated files... none found
writing... gitdb.1 { intro tutorial api algorithm changes } done
build succeeded.

The manual pages are in build/sphinx/man.
```
