### PR TITLE
.gitmodules: update smmap url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "smmap"]
 	path = gitdb/ext/smmap
-	url = https://github.com/Byron/smmap.git
+	url = https://github.com/gitpython-developers/smmap.git


### PR DESCRIPTION
Github.com is currenly redirecting the smmap url:
https://github.com/Byron/smmap.git
to:
https://github.com/gitpython-developers/smmap

For correctness we update to the url directly