### PR TITLE
Prefer `import` to `__import__`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 *.so
 .noseids
 *.sublime-workspace
+*.egg-info

--- a/gitdb/__init__.py
+++ b/gitdb/__init__.py
@@ -12,15 +12,12 @@ import os
 
 def _init_externals():
     """Initialize external projects by putting them into the path"""
-    for module in ('smmap',):
-        if 'PYOXIDIZER' not in os.environ:
-            sys.path.append(os.path.join(os.path.dirname(__file__), 'ext', module))
+    if 'PYOXIDIZER' not in os.environ:
+        where = os.path.join(os.path.dirname(__file__), 'ext', 'smmap')
+        if os.path.exists(where):
+            sys.path.append(where)
 
-        try:
-            __import__(module)
-        except ImportError as e:
-            raise ImportError("'%s' could not be imported, assure it is located in your PYTHONPATH" % module) from e
-        # END verify import
+    import smmap
     # END handle imports
 
 #} END initialization

--- a/gitdb/__init__.py
+++ b/gitdb/__init__.py
@@ -18,6 +18,7 @@ def _init_externals():
             sys.path.append(where)
 
     import smmap
+    del smmap
     # END handle imports
 
 #} END initialization


### PR DESCRIPTION
## What

In `__init__.py` there is a loop that invokes `__import__` here: https://github.com/gitpython-developers/gitdb/blob/3415e08bd9590d489f1071815863bfdde3083fb3/gitdb/__init__.py#L13

Since the loop only has one item this PR convert refactors it to use the standard `import`.

## Why

Some tooling only works with modules to be imported via `import` as the packages names are resolve-able without executing code, which `__import__` prevents.

## Possible Changes

If it is desired to have `smmap` added into `globals()` of `__init__.py`; I can remove the `del smmap` line. Right now it is there because `__import__`, which `import` is replacing, does *not* add `smmap` to `globals()`