### PR TITLE
Use ZLIB_RUNTIME_VERSION if available

### DIFF
--- a/gitdb/stream.py
+++ b/gitdb/stream.py
@@ -294,7 +294,7 @@ class DecompressMemMapReader(LazyMixin):
         # However, the zlib VERSIONs as well as the platform check is used to further match the entries in the 
         # table in the github issue. This is it ... it was the only way I could make this work everywhere.
         # IT's CERTAINLY GOING TO BITE US IN THE FUTURE ... .
-        if zlib.ZLIB_VERSION in ('1.2.7', '1.2.5') and not sys.platform == 'darwin':
+        if getattr(zlib, 'ZLIB_RUNTIME_VERSION', zlib.ZLIB_VERSION) in ('1.2.7', '1.2.5') and not sys.platform == 'darwin':
             unused_datalen = len(self._zip.unconsumed_tail)
         else:
             unused_datalen = len(self._zip.unconsumed_tail) + len(self._zip.unused_data)


### PR DESCRIPTION
The zlib version check introduced in #19 uses zlib.ZLIB_VERSION, which is not necessarily the actual version used at runtime. This PR attempts to use zlib.ZLIB_RUNTIME_VERSION instead (introduced in Python 3.3).