### PR TITLE
Enable Dependabot version updates for Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+      interval: "weekly"


### PR DESCRIPTION
This enables Dependabot version updates for GitHub Actions only (not Python dependencies), using the exact same configuration as [in GitPython](https://github.com/gitpython-developers/GitPython/blob/main/.github/dependabot.yml).

Since this repository is less active than the GitPython repository, I considered changing the `dependabot.yml` file to check for updates `monthly` rather than `weekly`. But I did not do so, because the GitHub Actions used in this repository's workflow are requested using major versions, and automatically use the latest minor (and, where applicable, patch) version in that major version automatically. As a result, Dependabot only needs to offer updates when a new major version comes out, which is a fairly infrequent event. So it is unlikely that this would ever generate an excessive number of automated pull requests.

Because actions versions were recently updated as part of #88 (in 32d12aa), if this pull request is merged then it should not be expected to cause Dependabot to generate any pull requests in the immediate future.