### PR TITLE
Test installing project on CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -26,10 +26,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
-    - name: Install dependencies
+    - name: Install project and dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install .
     - name: Lint with flake8
       run: |
         pip install flake8


### PR DESCRIPTION
This changes the CI workflow to install the project itself to get its dependency, rather than installing the dependency from `requirements.txt`. This is the more important thing to test, because it verifies that the project is installable and effectively declares the dependencies it needs.