### PR TITLE
Use actions/checkout feature to fetch all commits

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 1000
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
It appears the intent of specifying a `fetch-depth` of `1000` is that 1000 is greater enough than the current number of commits in the repository that it will fetch the whole branch history, now and for some time into the future.

Assuming that is the case, I recommend [doing a full fetch instead](https://github.com/actions/checkout?tab=readme-ov-file#Fetch-all-history-for-all-tags-and-branches), which this PR changes it to do. Setting the `fetch-depth` to a positive value fetches that many commits back (and the default value is 1), but setting it to 0 fetches all commits, as in a normal deep (full) fetch.