### PR TITLE
Don't cancel other jobs from the 3.12 job failing

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,6 +16,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        include:
+          - experimental: false
+          - python-version: "3.12"
+            experimental: true
+    continue-on-error: ${{ matrix.experimental }}
 
     steps:
     - uses: actions/checkout@v4
@@ -25,7 +30,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-        allow-prereleases: true
+        allow-prereleases: ${{ matrix.experimental }}
     - name: Install project and dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Because 3.12 is still a release candidate and if tests fail for it then one would always want to know if/how other versions also fail.

Note that a failure of the 3.12 job will still be treated as a failed check and will still cause the workflow to be considered to have failed (which we probably want). Setting `continue-on-error` for the job just overrides the default matrix `fail-fast` behavior, so he 3.12 job won't cause other jobs from the matrix to be cancelled if it fails. (Other jobs will still cause cancellation.)

I used a technique based on [the one in the GitHub Actions documentation](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures), but modified so all versions can be listed in one place and so the job names remain short, as they were before.

This also allows `actions/setup-python` to install a prerelease for 3.12 only, not for other releases. (This is less important, because only under very strange circumstances would only an old prerelease of a stable release be available to the CI runner. But treating 3.12 specially, as above, allows this to be done too, with no increase in complexity.)

This may or may not be considered worthwhile, given that it should be undone sometime not long after the stable 3.12.0 comes out. However, I think the `allow-preleases` override to `true` should be undone at that time, so it seems to me that the burden is much the same either way (and the stakes very low, either way, if it is left in place too long).