### PR TITLE
Revert "Drop support for EOL Python 3.7"

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           - experimental: false
           - python-version: "3.12"

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     zip_safe=False,
     install_requires=['smmap>=3.0.1,<6'],
     long_description="""GitDB is a pure-Python git object database""",
-    python_requires='>=3.8',
+    python_requires='>=3.7',
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -35,6 +35,7 @@ setup(
         "Operating System :: MacOS :: MacOS X",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
This brings back Python 3.7 support (allowing it to be installed on 3.7, and testing on 3.7 on CI), even though 3.7 is end-of-life. The reason is that support for 3.7 is not being dropped by GitPython yet, and there is value in keeping the version ranges supported by GitPython and gitdb consistent. This is noted in review comments on https://github.com/gitpython-developers/GitPython/pull/1654.

This reverts commit 875acb45cd8e9353c1911717bd2cd05b3e40ed05.