### PR TITLE
Fix top-of-file license URLs here in gitdb too

### DIFF
--- a/gitdb/__init__.py
+++ b/gitdb/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 """Initialize the object database module"""
 
 import sys

--- a/gitdb/base.py
+++ b/gitdb/base.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 """Module with basic data structures - they are designed to be lightweight and fast"""
 from gitdb.util import bin_to_hex
 

--- a/gitdb/db/__init__.py
+++ b/gitdb/db/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 
 from gitdb.db.base import *
 from gitdb.db.loose import *

--- a/gitdb/db/base.py
+++ b/gitdb/db/base.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 """Contains implementations of database retrieveing objects"""
 from gitdb.util import (
     join,

--- a/gitdb/db/git.py
+++ b/gitdb/db/git.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 from gitdb.db.base import (
     CompoundDB,
     ObjectDBW,

--- a/gitdb/db/loose.py
+++ b/gitdb/db/loose.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 from gitdb.db.base import (
     FileDBBase,
     ObjectDBR,

--- a/gitdb/db/mem.py
+++ b/gitdb/db/mem.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 """Contains the MemoryDatabase implementation"""
 from gitdb.db.loose import LooseObjectDB
 from gitdb.db.base import (

--- a/gitdb/db/pack.py
+++ b/gitdb/db/pack.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 """Module containing a database to deal with packs"""
 from gitdb.db.base import (
     FileDBBase,

--- a/gitdb/db/ref.py
+++ b/gitdb/db/ref.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 import codecs
 from gitdb.db.base import (
     CompoundDB,

--- a/gitdb/exc.py
+++ b/gitdb/exc.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 """Module with common exceptions"""
 from gitdb.util import to_hex_sha
 

--- a/gitdb/fun.py
+++ b/gitdb/fun.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 """Contains basic c-functions which usually contain performance critical code
 Keeping this code separate from the beginning makes it easier to out-source
 it into c later, if required"""

--- a/gitdb/pack.py
+++ b/gitdb/pack.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 """Contains PackIndexFile and PackFile implementations"""
 import zlib
 
@@ -263,7 +263,7 @@ class PackIndexFile(LazyMixin):
     def close(self):
         mman.force_map_handle_removal_win(self._indexpath)
         self._cursor = None
-        
+
     def _set_cache_(self, attr):
         if attr == "_packfile_checksum":
             self._packfile_checksum = self._cursor.map()[-40:-20]
@@ -528,7 +528,7 @@ class PackFile(LazyMixin):
     def close(self):
         mman.force_map_handle_removal_win(self._packpath)
         self._cursor = None
-        
+
     def _set_cache_(self, attr):
         # we fill the whole cache, whichever attribute gets queried first
         self._cursor = mman.make_cursor(self._packpath).use_region()

--- a/gitdb/stream.py
+++ b/gitdb/stream.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 
 from io import BytesIO
 
@@ -140,7 +140,7 @@ class DecompressMemMapReader(LazyMixin):
     def close(self):
         """Close our underlying stream of compressed bytes if this was allowed during initialization
         :return: True if we closed the underlying stream
-        :note: can be called safely 
+        :note: can be called safely
         """
         if self._close:
             if hasattr(self._m, 'close'):
@@ -287,11 +287,11 @@ class DecompressMemMapReader(LazyMixin):
         # if we hit the end of the stream
         # NOTE: Behavior changed in PY2.7 onward, which requires special handling to make the tests work properly.
         # They are thorough, and I assume it is truly working.
-        # Why is this logic as convoluted as it is ? Please look at the table in 
+        # Why is this logic as convoluted as it is ? Please look at the table in
         # https://github.com/gitpython-developers/gitdb/issues/19 to learn about the test-results.
         # Basically, on py2.6, you want to use branch 1, whereas on all other python version, the second branch
-        # will be the one that works. 
-        # However, the zlib VERSIONs as well as the platform check is used to further match the entries in the 
+        # will be the one that works.
+        # However, the zlib VERSIONs as well as the platform check is used to further match the entries in the
         # table in the github issue. This is it ... it was the only way I could make this work everywhere.
         # IT's CERTAINLY GOING TO BITE US IN THE FUTURE ... .
         if getattr(zlib, 'ZLIB_RUNTIME_VERSION', zlib.ZLIB_VERSION) in ('1.2.7', '1.2.5') and not sys.platform == 'darwin':

--- a/gitdb/test/__init__.py
+++ b/gitdb/test/__init__.py
@@ -1,4 +1,4 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/

--- a/gitdb/test/db/__init__.py
+++ b/gitdb/test/db/__init__.py
@@ -1,4 +1,4 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/

--- a/gitdb/test/db/lib.py
+++ b/gitdb/test/db/lib.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 """Base classes for object db testing"""
 from gitdb.test.lib import (
     with_rw_directory,

--- a/gitdb/test/db/test_git.py
+++ b/gitdb/test/db/test_git.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 import os
 from gitdb.test.db.lib import (
     TestDBBase,

--- a/gitdb/test/db/test_loose.py
+++ b/gitdb/test/db/test_loose.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 from gitdb.test.db.lib import (
     TestDBBase,
     with_rw_directory

--- a/gitdb/test/db/test_mem.py
+++ b/gitdb/test/db/test_mem.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 from gitdb.test.db.lib import (
     TestDBBase,
     with_rw_directory

--- a/gitdb/test/db/test_pack.py
+++ b/gitdb/test/db/test_pack.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 from gitdb.test.db.lib import (
     TestDBBase,
     with_rw_directory,

--- a/gitdb/test/db/test_ref.py
+++ b/gitdb/test/db/test_ref.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 from gitdb.test.db.lib import (
     TestDBBase,
     with_rw_directory,

--- a/gitdb/test/lib.py
+++ b/gitdb/test/lib.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 """Utilities used in ODB testing"""
 from gitdb import OStream
 

--- a/gitdb/test/performance/lib.py
+++ b/gitdb/test/performance/lib.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 """Contains library functions"""
 from gitdb.test.lib import TestBase
 

--- a/gitdb/test/performance/test_pack.py
+++ b/gitdb/test/performance/test_pack.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 """Performance tests for object store"""
 
 from gitdb.test.performance.lib import (

--- a/gitdb/test/performance/test_pack_streaming.py
+++ b/gitdb/test/performance/test_pack_streaming.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 """Specific test for pack streams only"""
 
 from gitdb.test.performance.lib import (

--- a/gitdb/test/performance/test_stream.py
+++ b/gitdb/test/performance/test_stream.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 """Performance data streaming performance"""
 
 from gitdb.test.performance.lib import TestBigRepoR

--- a/gitdb/test/test_base.py
+++ b/gitdb/test/test_base.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 """Test for object db"""
 from gitdb.test.lib import (
     TestBase,

--- a/gitdb/test/test_example.py
+++ b/gitdb/test/test_example.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 """Module with examples from the tutorial section of the docs"""
 import os
 from gitdb.test.lib import TestBase

--- a/gitdb/test/test_pack.py
+++ b/gitdb/test/test_pack.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 """Test everything about packs reading and writing"""
 from gitdb.test.lib import (
     TestBase,
@@ -242,7 +242,7 @@ class TestPack(TestBase):
         # END for each info
         assert count == len(pack_objs)
         entity.close()
-        
+
     def test_pack_64(self):
         # TODO: hex-edit a pack helping us to verify that we can handle 64 byte offsets
         # of course without really needing such a huge pack

--- a/gitdb/test/test_stream.py
+++ b/gitdb/test/test_stream.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 """Test for object db"""
 
 from gitdb.test.lib import (

--- a/gitdb/test/test_util.py
+++ b/gitdb/test/test_util.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 """Test for object db"""
 import tempfile
 import os

--- a/gitdb/typ.py
+++ b/gitdb/typ.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 """Module containing information about types known to the database"""
 
 str_blob_type = b'blob'

--- a/gitdb/util.py
+++ b/gitdb/util.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010, 2011 Sebastian Thiel (byronimo@gmail.com) and contributors
 #
 # This module is part of GitDB and is released under
-# the New BSD License: http://www.opensource.org/licenses/bsd-license.php
+# the New BSD License: https://opensource.org/license/bsd-3-clause/
 import binascii
 import os
 import mmap


### PR DESCRIPTION
This is the `gitdb` part of the fix for the top-of-file license URLs that have come to point to a page about a related but different license from the one `GitPython` and `gitdb` are (intended to be) offered under.

See https://github.com/gitpython-developers/GitPython/pull/1662 for details about the problem and how it came about.