### PR TITLE
No longer treat 3.12 as experimental on CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,8 +14,6 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
         - experimental: false
-        - python-version: "3.12"
-          experimental: true
     continue-on-error: ${{ matrix.experimental }}
 
     steps:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -3,11 +3,7 @@
 
 name: Python package
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
@@ -17,9 +13,9 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
-          - experimental: false
-          - python-version: "3.12"
-            experimental: true
+        - experimental: false
+        - python-version: "3.12"
+          experimental: true
     continue-on-error: ${{ matrix.experimental }}
 
     steps:


### PR DESCRIPTION
Python 3.12.0 stable has been released, as well as now being [available via setup-python](https://github.com/actions/python-versions/blob/main/versions-manifest.json), and these tests have been passing with the release candidate. So this changes the CI test workflow to no longer treat it as experimental. This has two effects:

- `continue-on-error` is no longer set to true for 3.12, so 3.12 is no longer special-cased to refrain from cancelling other test jobs when its test job fails. This is the more significant effect.
- 3.12 can longer be selected as a prerelease. This is the only effect in GitPython, but the less significant of the two effects here and in smmap (GitPython sets `fail-fast` to `false`, so one job failing never automatically cancels another job).

With respect to the latter, as well as in a broad conceptual sense, this PR corresponds to https://github.com/gitpython-developers/GitPython/pull/1689.

**In addition to those changes**, I have also changed this to be triggered the same ways as in GitPython, so that CI test jobs run on all branches. This makes it easier to test changes to CI without, or before, opening a PR. (It also reduces the temptation to use one's fork's default branch for feature development.) However, if you prefer this not be done, I'd be pleased to remove it.

The exactly corresponding PR to this one, in smmap, is https://github.com/gitpython-developers/smmap/pull/54.