### PR TITLE
Have Dependabot update smmap submodule dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,9 @@ updates:
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-      interval: "weekly"
+    interval: "weekly"
+
+- package-ecosystem: "gitsubmodule"
+  directory: "/"
+  schedule:
+    interval: "monthly"


### PR DESCRIPTION
This makes Dependabot open version update PRs for submodules (which here is just smmap), as well as GitHub Actions. This is like https://github.com/gitpython-developers/GitPython/pull/1702.