### PR TITLE
Never add a vendored smmap directory to sys.path

### DIFF
--- a/gitdb/__init__.py
+++ b/gitdb/__init__.py
@@ -4,33 +4,11 @@
 # the New BSD License: https://opensource.org/license/bsd-3-clause/
 """Initialize the object database module"""
 
-import sys
-import os
-
-#{ Initialization
-
-
-def _init_externals():
-    """Initialize external projects by putting them into the path"""
-    if 'PYOXIDIZER' not in os.environ:
-        where = os.path.join(os.path.dirname(__file__), 'ext', 'smmap')
-        if os.path.exists(where):
-            sys.path.append(where)
-
-    import smmap
-    del smmap
-    # END handle imports
-
-#} END initialization
-
-_init_externals()
-
 __author__ = "Sebastian Thiel"
 __contact__ = "byronimo@gmail.com"
 __homepage__ = "https://github.com/gitpython-developers/gitdb"
 version_info = (4, 0, 11)
 __version__ = '.'.join(str(i) for i in version_info)
-
 
 # default imports
 from gitdb.base import *


### PR DESCRIPTION
This removes the logic that appended the git submodule directory for `smmap` to `sys.path` under most circumstances when the version of `gitdb` was not from PyPI. Now `gitdb` does not modify `sys.path`.

See [GitPython#1717](https://github.com/gitpython-developers/GitPython/issues/1717) and [GitPython#1720](https://github.com/gitpython-developers/GitPython/pull/1720) for context. This change is roughly equivalent to the change to GitPython, though as noted the behavior being eliminated is subtly different here and there.

Please note that this does *not* make any documentation changes (and the changes in #103 are not related to this).