### PR TITLE
Set Dependabot submodule update cadence to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
 - package-ecosystem: "gitsubmodule"
   directory: "/"
   schedule:
-    interval: "monthly"
+    interval: "weekly"


### PR DESCRIPTION
This changes it from monthly to weekly. See #99 for general context and [GitPython#1702 (comment)](https://github.com/gitpython-developers/GitPython/pull/1702#issuecomment-1761182333) for where this was requested as an eventual change.

With recent and proposed changes to gitdb, it seems to make sense to propose this now. I've done this in its own PR so this change can be applied at whatever point is most convenient, without being directly tied to any of the other proposed changes.