### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
         - experimental: false
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,12 +8,17 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        os: [ubuntu-latest]
+        experimental: [false]
         include:
-        - experimental: false
+        - python-version: "3.7"
+          os: ubuntu-22.04
+          experimental: false
     continue-on-error: ${{ matrix.experimental }}
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: 3 :: Only",
     ]
 )


### PR DESCRIPTION
Python 3.13 is out, so it'd be nice if the next release of gitdb to PyPI included it in its metadata.

Though you might wanna wait for https://github.com/gitpython-developers/GitPython/pull/1955?

https://pyreadiness.org/3.13/