### PR TITLE
Potential Race Condition Fix - OS Rename & Chmod - PermissionError

### DIFF
--- a/gitdb/db/loose.py
+++ b/gitdb/db/loose.py
@@ -54,6 +54,7 @@ from gitdb.utils.encoding import force_bytes
 import tempfile
 import os
 import sys
+import time
 
 
 __all__ = ('LooseObjectDB', )
@@ -205,7 +206,7 @@ class LooseObjectDB(FileDBBase, ObjectDBR, ObjectDBW):
             # END assure target stream is closed
         except:
             if tmp_path:
-                os.remove(tmp_path)
+                remove(tmp_path)
             raise
         # END assure tmpfile removal on error
 
@@ -228,9 +229,25 @@ class LooseObjectDB(FileDBBase, ObjectDBR, ObjectDBW):
                 rename(tmp_path, obj_path)
             # end rename only if needed
 
-            # make sure its readable for all ! It started out as rw-- tmp file
-            # but needs to be rwrr
-            chmod(obj_path, self.new_objects_mode)
+            # Ensure rename is actually done and file is stable
+            # Retry up to 14 times - exponential wait & retry in ms.
+            # The total maximum wait time is 1000ms, which should be vastly enough for the
+            # OS to return and commit the file to disk.
+            for exp_backoff_ms in [1, 4, 9, 16, 25, 36, 49, 64, 81, 100, 121, 144, 169, 181]:
+                with suppress(PermissionError):
+                    # make sure its readable for all ! It started out as rw-- tmp file
+                    # but needs to be rwrr
+                    chmod(obj_path, self.new_objects_mode)
+                    break
+                time.sleep(exp_backoff_ms / 1000.0)
+            else:
+                raise PermissionError(
+                    "Impossible to apply `chmod` to file {}".format(obj_path)
+                )
+
+            # Cleanup
+            with suppress(FileNotFoundError):
+                remove(tmp_path)
         # END handle dry_run
 
         istream.binsha = hex_to_bin(hexsha)

--- a/gitdb/db/loose.py
+++ b/gitdb/db/loose.py
@@ -245,9 +245,6 @@ class LooseObjectDB(FileDBBase, ObjectDBR, ObjectDBW):
                     "Impossible to apply `chmod` to file {}".format(obj_path)
                 )
 
-            # Cleanup
-            with suppress(FileNotFoundError):
-                remove(tmp_path)
         # END handle dry_run
 
         istream.binsha = hex_to_bin(hexsha)


### PR DESCRIPTION
There is a really flaky and hard to debug bug when using `gitdb` at least on MacOS (M-Processor) using Docker (`docker.io/python:3.13` image).

I have only been able to reproduce this error within `pytest` on my laptop (Apple M4 laptop).

I completely randomly get:

```python
repo = Repo(........)  # Repo Created using `GitPython`
[...]
repo.index.add("*")

    ~~~~~~~~~~~~~~^^^^^
  File "/usr/local/lib/python3.13/site-packages/git/index/base.py", line 885, in add
    entries_added.extend(self._entries_for_paths(paths, path_rewriter, fprogress, entries))
                         ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/git/util.py", line 176, in wrapper
    return func(self, *args, **kwargs)
  File "/usr/local/lib/python3.13/site-packages/git/index/util.py", line 111, in set_git_working_dir
    return func(self, *args, **kwargs)
  File "/usr/local/lib/python3.13/site-packages/git/index/base.py", line 745, in _entries_for_paths
    entries_added.append(self._store_path(filepath, fprogress))
                         ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/git/index/base.py", line 698, in _store_path
    istream = self.repo.odb.store(IStream(Blob.type, st.st_size, stream))
  File "/usr/local/lib/python3.13/site-packages/gitdb/db/loose.py", line 233, in store
    chmod(obj_path, self.new_objects_mode)
    ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
PermissionError: [Errno 1] Operation not permitted: '/git_projects/<GIT_PROJECT_NAME>/.git/objects/9d/961f54d04e15cef0e525d1cb3d937bd7b82b04'
```

When you inspect a little bit that `obj_path` - everything looks absolutely fine as far as I can tell. I have no idea what could trigger this `PermissionError`. The script is executing under the user `dev-user:dev-user` of UID/GID: `1000:1000`

```python
os.getuid()=1000
pwd.getpwuid(os.getuid())=pwd.struct_passwd(pw_name='dev-user', pw_passwd='x', pw_uid=1000, pw_gid=1000, pw_gecos='', pw_dir='/home/dev-user', pw_shell='/bin/bash')
os.stat(obj_path)=os.stat_result(st_mode=33152, st_ino=3713822, st_dev=65025, st_nlink=1, st_uid=1000, st_gid=1000, st_size=473, st_atime=1734989354, st_mtime=1734989354, st_ctime=1734989354)
Path(obj_path).exists()=True
Path(obj_path).owner()='dev-user'
Path(obj_path).group()='dev-user'
```

So clearly something is not going well.

Looking a little bit more in detail, turns out the error is always happening in scenario B - but not systematically in scenario B:

```python
if isfile(obj_path):
    remove(tmp_path)
    print("SCENARIO A !!!!!!!!!!!!!!!")
else:
    rename(tmp_path, obj_path)
    print("SCENARIO B !!!!!!!!!!!!!!!")
```

There might be an interference between `tempfile.mkstemp`, `os.rename` and `os.chmod`. Not sure which one.

It seems like a retry loop with a small temporization seems to mitigate the problem.

One supposition is that `os.rename` might not entirely complete by the time it returns. Or some file descriptors might be corrupted. Unfortunately, it's really really hard for me to debug and I'm not sure even what to look for.