### PR TITLE
Add CI test job for no-GIL (free-threaded) Python 3.13

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.13t"]
         os: [ubuntu-latest]
         experimental: [false]
         include:


### PR DESCRIPTION
See https://github.com/gitpython-developers/GitPython/issues/2005.

The rationale is that, while this is probably less important to do in gitdb and smmap, any failure that arises for this in GitPython would likely raise the question of whether a correspond problem has begun to occur in gitdb and smmap. (Both gitdb and smmap provide helpers used in GitPython even when the in-memory object database is not used, and failures may plausibly occur for reasons other than code changes because of the finicky nature of concurrency bugs and the potential for interactions affected by the runner image.)