### PR TITLE
fix: replace deprecated codecs.open with built-in open (#128)

### DIFF
--- a/gitdb/db/ref.py
+++ b/gitdb/db/ref.py
@@ -2,7 +2,6 @@
 #
 # This module is part of GitDB and is released under
 # the New BSD License: https://opensource.org/license/bsd-3-clause/
-import codecs
 from gitdb.db.base import (
     CompoundDB,
 )
@@ -42,7 +41,7 @@ class ReferenceDB(CompoundDB):
         # try to get as many as possible, don't fail if some are unavailable
         ref_paths = list()
         try:
-            with codecs.open(self._ref_file, 'r', encoding="utf-8") as f:
+            with open(self._ref_file, 'r', encoding="utf-8") as f:
                 ref_paths = [l.strip() for l in f]
         except OSError:
             pass


### PR DESCRIPTION
Fixes #128.

## What changed

`gitdb/db/ref.py:45` used `codecs.open(self._ref_file, 'r', encoding="utf-8")`. Replaced it with the built-in `open(self._ref_file, 'r', encoding="utf-8")` and dropped the now-unused `import codecs`.

## Why this matters

Running the test suite under Python 3.14 emits the warning quoted in the issue:

```
gitdb/db/ref.py:45: DeprecationWarning: codecs.open() is deprecated. Use open() instead.
  with codecs.open(self._ref_file, 'r', encoding="utf-8") as f:
```

The built-in `open()` has accepted the `encoding` keyword since Python 3.0, and the call site already passed `encoding="utf-8"`, so the replacement is byte-for-byte equivalent on every supported Python version. @Byron's comment on the issue ("if using `open` in its place is backwards compatible within the v3 version of python, this should be an easy fix") is exactly what this is.

## Verification

- `pytest gitdb/test/db/test_ref.py` — 1 passed
- `grep -rn 'codecs.open' --include='*.py'` — 0 matches after the change